### PR TITLE
remove com.apple.eawt dependency

### DIFF
--- a/jgr-java/src/main/java/org/rosuda/JGR/JGR.java
+++ b/jgr-java/src/main/java/org/rosuda/JGR/JGR.java
@@ -1,7 +1,6 @@
 package org.rosuda.JGR;
 
 
-import com.apple.eawt.*;
 import org.rosuda.JGR.toolkit.*;
 import org.rosuda.JGR.util.ErrorMsg;
 import org.rosuda.REngine.*;
@@ -563,30 +562,6 @@ public class JGR {
         System.setProperty("apple.awt.textantialiasing", "true");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name", "JGR");
 
-
-        if (Common.isMac()) {
-            Application macApplication = Application.getApplication();
-
-            macApplication.setAboutHandler(new AboutHandler() {
-                public void handleAbout(AppEvent.AboutEvent aboutEvent) {
-                    new AboutDialog();
-                }
-            });
-
-            macApplication.setPreferencesHandler(new PreferencesHandler() {
-                public void handlePreferences(AppEvent.PreferencesEvent preferencesEvent) {
-                    PrefDialog inst = PrefDialog.showPreferences(null);
-                    inst.setLocationRelativeTo(null);
-                    inst.setVisible(true);
-                }
-            });
-
-            macApplication.setQuitHandler(new QuitHandler() {
-                public void handleQuitRequestWith(AppEvent.QuitEvent quitEvent, QuitResponse quitResponse) {
-                    MAINRCONSOLE.exit();
-                }
-            });
-        }
 
         JGRmain = true;
         arguments = args;


### PR DESCRIPTION
Hi,

I'm filing this as a pull request because there is no "Issues" tab for this project.

On Fedora 23, with:

$ java -version
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on
openjdk version "1.8.0_111"
OpenJDK Runtime Environment (build 1.8.0_111-b16)
OpenJDK 64-Bit Server VM (build 25.111-b16, mixed mode)
$ 

JGR fails to load with:

> JGR()
#!/bin/sh

export R_HOME="/usr/lib64/R"
export R_ARCH=""
export R_LIBS="/usr/lib64/R/library:/usr/share/R/library"
export R_LIBS_USER="~/R/x86_64-redhat-linux-gnu-library/3.3"
export JAVA_LD_PATH="/usr/lib64/R/lib:/usr/lib/jvm/jre/lib/amd64/server:/usr/lib/jvm/jre/lib/amd64:/usr/lib/jvm/java/lib/amd64:/usr/java/packages/lib/amd64:/lib:/usr/lib:@JAVA_LD@"
'/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.111-1.b16.fc23.x86_64/jre/bin/java' -cp '/usr/lib64/R/library/rJava/java/boot' -Drjava.class.path='/usr/lib64/R/library/rJava/jri/JRI.jar:/usr/lib64/R/library/JGR/java/JGR.jar:/usr/lib64/R/etc/classes:/usr/lib64/R/etc/classes/classes.jar' -Drjava.path='/usr/lib64/R/library/rJava' -Dmain.class=org.rosuda.JGR.JGR  -Djgr.load.pkgs=yes  -Dr.arch=  RJavaClassLoader 
> Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on
Exception in thread "main" java.lang.NoClassDefFoundError: com/apple/eawt/AboutHandler
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
	at java.lang.Class.getMethod0(Class.java:3018)
	at java.lang.Class.getMethod(Class.java:1784)
	at RJavaClassLoader.bootClass(RJavaClassLoader.java:531)
	at RJavaClassLoader.main(RJavaClassLoader.java:602)
Caused by: java.lang.ClassNotFoundException
	at RJavaClassLoader.findClass(RJavaClassLoader.java:383)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 7 more

> 

Here is the output with -DrJava.debug=1:

$ /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.111-1.b16.fc23.x86_64/jre/bin/java -cp '/usr/lib64/R/library/rJava/java/boot' -DrJava.debug=1 -Drjava.class.path='/usr/lib64/R/library/rJava/jri/JRI.jar:/usr/lib64/R/library/JGR/java/JGR.jar:/usr/lib64/R/etc/classes:/usr/lib64/R/etc/classes/classes.jar' -Drjava.path='/usr/lib64/R/library/rJava' -Dmain.class=org.rosuda.JGR.JGR  -Djgr.load.pkgs=yes  -Dr.arch=  RJavaClassLoader 
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on
RJavaClassLoader("/usr/lib64/R/library/rJava","/usr/lib64/R/library/rJava/libs")
 - primary loader
 - registered JRI: /usr/lib64/R/library/rJava/jri/libjri.so
RJavaClassLoader initialized.

Registered libraries:
  jri: '/usr/lib64/R/library/rJava/jri/libjri.so'
  rJava: '/usr/lib64/R/library/rJava/libs/rJava.so'

Registered class paths:
  '/usr/lib64/R/library/rJava/java'

-- end of class loader report --
RJavaClassLoader: added '/usr/lib64/R/library/rJava/jri/JRI.jar' to the URL class path loader
RJavaClassLoader: adding Java archive file '/usr/lib64/R/library/rJava/jri/JRI.jar' to the internal class path
RJavaClassLoader: added '/usr/lib64/R/library/JGR/java/JGR.jar' to the URL class path loader
RJavaClassLoader: adding Java archive file '/usr/lib64/R/library/JGR/java/JGR.jar' to the internal class path
RJavaClassLoader: added '/usr/lib64/R/etc/classes' to the URL class path loader
WARNING: the path '/usr/lib64/R/etc/classes' does NOT exist, it will NOT be added to the internal class path!
RJavaClassLoader: added '/usr/lib64/R/etc/classes/classes.jar' to the URL class path loader
WARNING: the path '/usr/lib64/R/etc/classes/classes.jar' does NOT exist, it will NOT be added to the internal class path!
RJavaClassLoader@2a139a55.findClass(org.rosuda.JGR.JGR)
RJavaClassLoader: found class org.rosuda.JGR.JGR using URL loader
RJavaClassLoader@2a139a55.findClass(com.apple.eawt.AboutHandler)
 - URL loader did not find it: java.lang.ClassNotFoundException: com.apple.eawt.AboutHandler
RJavaClassLoader.findClass("com.apple.eawt.AboutHandler")
 - trying class path "/usr/lib64/R/library/rJava/java"
   Directory, can get '/usr/lib64/R/library/rJava/java/com/apple/eawt/AboutHandler.class'? NO
 - trying class path "/usr/lib64/R/library/rJava/jri/JRI.jar"
   JAR file, can get 'com/apple/eawt/AboutHandler'? NO
 - trying class path "/usr/lib64/R/library/JGR/java/JGR.jar"
   JAR file, can get 'com/apple/eawt/AboutHandler'? NO
    >> ClassNotFoundException 
Exception in thread "main" java.lang.NoClassDefFoundError: com/apple/eawt/AboutHandler
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
	at java.lang.Class.getMethod0(Class.java:3018)
	at java.lang.Class.getMethod(Class.java:1784)
	at RJavaClassLoader.bootClass(RJavaClassLoader.java:531)
	at RJavaClassLoader.main(RJavaClassLoader.java:602)
Caused by: java.lang.ClassNotFoundException
	at RJavaClassLoader.findClass(RJavaClassLoader.java:383)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 7 more
$ 

When I remove the non-standard com.apple references, as the hack in this pull request does, JGR runs.  I don't have a JRE with com.apple classes to test with, so I don't know what the right solution is.  The import causes a compilation error on a JDK that doesn't have com.apple classes, so for portability those references should be made purely dynamically.  To fix the runtime error(s) it might be enough to catch the com/apple ClassNotFoundException(s) and continue.

Thank you,
Thomas
